### PR TITLE
Potential fixes to run worker on test input

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,5 @@
-/data
 /misc
 /model
-/config
-/config.yml
 /tests
 .venv
 .flake8

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,7 @@
+/data
 /misc
 /model
+/config
 /tests
 .venv
 .flake8

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM docker.io/python:3.10
 # - Injecting config.yml: /root/.DANE
 # - Mount point for input & output files: /mnt/dane-fs
 # - Storing the source code: /src
-RUN mkdir /root/.DANE /mnt/dane-fs /src
+RUN mkdir /root/.DANE /mnt/dane-fs /src /src/data
 
 WORKDIR /src
 
@@ -18,6 +18,9 @@ COPY pyproject.toml poetry.lock ./
 RUN pip install poetry==1.8.2
 
 RUN poetry install --without dev --no-root && rm -rf $POETRY_CACHE_DIR
+
+# copy the config file to /root/.DANE
+COPY ./config/config.yml /root/.DANE
 
 COPY . /src
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM docker.io/python:3.10
 # - Mount point for input & output files: /mnt/dane-fs
 # - Storing the source code: /src
 # - Storing the input file to be used while testing: /src/data
-RUN mkdir /root/.DANE /mnt/dane-fs /src /src/data
+RUN mkdir /root/.DANE /mnt/dane-fs /src /data
 
 WORKDIR /src
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM docker.io/python:3.10
 # - Injecting config.yml: /root/.DANE
 # - Mount point for input & output files: /mnt/dane-fs
 # - Storing the source code: /src
+# - Storing the input file to be used while testing: /src/data
 RUN mkdir /root/.DANE /mnt/dane-fs /src /src/data
 
 WORKDIR /src

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,6 @@ RUN pip install poetry==1.8.2
 
 RUN poetry install --without dev --no-root && rm -rf $POETRY_CACHE_DIR
 
-# copy the config file to /root/.DANE
-COPY ./config/config.yml /root/.DANE
-
 COPY . /src
 
 ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # dane-example-worker
+
+## Locally test the worker
+
+To locally test the worker, first navigate to the directory where the repository is located, then run this command:
+
+```
+docker run --mount type=bind,source="$(pwd)"config,target=/root/.DANE --mount type=bind,source="$(pwd)"data,target=/src/data --rm workshop --run-test-file
+```
+
+Explanation:
+
+- `--mount` is responsible for adding the files required for testing. It essentially copies the files from your local directory to a target directory within the container
+- `"$(pwd)"` outputs the current directory you are in. This is required because Docker uses the absolute paths when copying files to/from a container
+- The first `--mount` copies the `config` folder, whereas the second one copies the input file
+- It is important to have the `--mount` before calling the actual image, otherwise `--mount` will be treated as a flag of the `worker.py` script to be executed

--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ docker build . -t dane-example-worker
 ```
 3. Run the Docker image:
 ```
-docker run --mount type=bind,source="$(pwd)"config,target=/root/.DANE --mount type=bind,source="$(pwd)"data,target=/data --rm dane-example-worker --run-test-file
+docker run --mount type=bind,source="$(pwd)"config,target=/root/.DANE \
+    --mount type=bind,source="$(pwd)"data,target=/data \
+    --rm dane-example-worker --run-test-file
 ```
 
 Explanation:

--- a/README.md
+++ b/README.md
@@ -2,10 +2,16 @@
 
 ## Locally test the worker
 
-To locally test the worker, first navigate to the directory where the repository is located, then run this command:
+To locally test the worker:
 
+1. Navigate to the directory where the repository is cloned, 
+2. Build the Docker image:
 ```
-docker run --mount type=bind,source="$(pwd)"config,target=/root/.DANE --mount type=bind,source="$(pwd)"data,target=/src/data --rm workshop --run-test-file
+docker build . -t dane-example-worker
+```
+3. Run the Docker image:
+```
+docker run --mount type=bind,source="$(pwd)"config,target=/root/.DANE --mount type=bind,source="$(pwd)"data,target=/data --rm dane-example-worker --run-test-file
 ```
 
 Explanation:
@@ -14,3 +20,5 @@ Explanation:
 - `"$(pwd)"` outputs the current directory you are in. This is required because Docker uses the absolute paths when copying files to/from a container
 - The first `--mount` copies the `config` folder, whereas the second one copies the input file
 - It is important to have the `--mount` before calling the actual image, otherwise `--mount` will be treated as a flag of the `worker.py` script to be executed
+
+Make sure to build the image every time the code is changed to propagate the changes to the Docker image.

--- a/config/config.yml
+++ b/config/config.yml
@@ -25,7 +25,7 @@ ELASTICSEARCH:
     SCHEME: http
     INDEX: dane-index-k8s
 FILE_SYSTEM:
-    BASE_MOUNT: data # data when running locally
+    BASE_MOUNT: /data # data when running locally
     INPUT_DIR: input-files
     OUTPUT_DIR: output-files
 INPUT:


### PR DESCRIPTION
Linked to #19 

I managed to make the worker run on test input. The error I am getting now (which I think it's fine for test input) is that the output cannot be uploaded to S3.

I removed /data and /config ignores in `.dockerignore`, as well as explicitly copied the `config.yml` file to `/root/.DANE` inside the `Dockerfile`.

I know `data` and `config.yml` should normally NOT be copied if the Docker image is published, but since this is an example worker meant as a starting template and for development/testing purposes only, this is acceptable.

I suggest making some sort of configuration for Docker such that you can have `data` and `config.yml` when testing, but in prod ignore them.